### PR TITLE
Fix/trac 52925 -- Add unit tests 

### DIFF
--- a/tests/phpunit/tests/rest-api/rest-autosaves-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-autosaves-controller.php
@@ -319,6 +319,49 @@ class WP_Test_REST_Autosaves_Controller extends WP_Test_REST_Post_Type_Controlle
 		$this->check_create_autosave_response( $response );
 	}
 
+	/**
+	 * @group 52925
+	 */
+	public function test_create_item_invalid_integration() {
+		$request = new WP_REST_Request( 'POST', '/wp/v2/posts/' . self::$post_id . '/autosaves' );
+		$request->add_header( 'content-type', 'application/x-www-form-urlencoded' );
+		$params = $this->set_post_data(
+			array(
+				'id' => REST_TESTS_IMPOSSIBLY_HIGH_NUMBER,
+			)
+		);
+		$request->set_body_params( $params );
+
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertErrorResponse( 'rest_post_invalid_id', $response, 404 );
+	}
+
+	/**
+	 * @group 52925
+	 */
+	public function test_create_item_invalid_unit() {
+		$autosaves_controller = new WP_REST_Autosaves_Controller('post');
+		$response = $autosaves_controller->create_item(
+			array(
+				'id' => REST_TESTS_IMPOSSIBLY_HIGH_NUMBER
+			)
+		);
+		$this->assertErrorResponse( 'rest_post_invalid_id', $response, 404 );
+	}
+
+	/**
+	 * @group 52925
+	 */
+	public function test_create_post_autosave_invalid() {
+		$autosaves_controller = new WP_REST_Autosaves_Controller('post');
+		$response = $autosaves_controller->create_post_autosave(
+			array(
+				'ID' => REST_TESTS_IMPOSSIBLY_HIGH_NUMBER
+			)
+		);
+		$this->assertErrorResponse( 'rest_post_invalid_id', $response, 404 );
+	}
+
 	public function test_update_item() {
 		wp_set_current_user( self::$editor_id );
 		$request = new WP_REST_Request( 'POST', '/wp/v2/posts/' . self::$post_id . '/autosaves' );

--- a/tests/phpunit/tests/rest-api/rest-autosaves-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-autosaves-controller.php
@@ -320,7 +320,7 @@ class WP_Test_REST_Autosaves_Controller extends WP_Test_REST_Post_Type_Controlle
 	}
 
 	/**
-	 * @group 52925
+	 * @ticket 52925
 	 */
 	public function test_create_item_invalid_integration() {
 		$request = new WP_REST_Request( 'POST', '/wp/v2/posts/' . self::$post_id . '/autosaves' );
@@ -337,7 +337,7 @@ class WP_Test_REST_Autosaves_Controller extends WP_Test_REST_Post_Type_Controlle
 	}
 
 	/**
-	 * @group 52925
+	 * @ticket 52925
 	 */
 	public function test_create_item_invalid_unit() {
 		$autosaves_controller = new WP_REST_Autosaves_Controller('post');
@@ -350,7 +350,7 @@ class WP_Test_REST_Autosaves_Controller extends WP_Test_REST_Post_Type_Controlle
 	}
 
 	/**
-	 * @group 52925
+	 * @ticket 52925
 	 */
 	public function test_create_post_autosave_invalid() {
 		$autosaves_controller = new WP_REST_Autosaves_Controller('post');


### PR DESCRIPTION
Hi! I have some suggestions for unit tests here.

The first already passes because of a check performed by `create_item_permissions_check`.
The next two tests check the updated methods directly without doing a full REST dispatch.

Trac ticket: https://core.trac.wordpress.org/ticket/52925
